### PR TITLE
Add a bunch of tests from bluebird

### DIFF
--- a/test/parallel/test-util-promisify.js
+++ b/test/parallel/test-util-promisify.js
@@ -69,3 +69,97 @@ const stat = promisify(fs.stat);
     assert.strictEqual(value, undefined);
   }));
 }
+
+{
+  function fn(err, val, callback) {
+    callback(err, val);
+  }
+  promisify(fn)(null, 42).then(common.mustCall(value => {
+    assert.strictEqual(value, 42);
+  }))
+}
+
+{
+  function fn(err, val, callback) {
+    callback(err, val);
+  }
+  promisify(fn)(new Error('oops'), null).catch(common.mustCall(err => {
+    assert.strictEqual(err.message, 'oops');
+  }))
+}
+
+{
+  function fn(err, val, callback) {
+    callback(err, val);
+  }
+
+  (async () => {
+    const value = await promisify(fn)(null, 42);
+    assert.strictEqual(value, 42);
+  })();
+}
+
+{
+  const o = {};
+  const fn = promisify(function (cb) {
+
+    cb(null, this === o);
+  });
+
+  o.fn = fn;
+
+  o.fn().then(common.mustCall(function (val) {
+    assert(val);
+  }));
+}
+
+{
+  const err = new Error('Should not have called the callback with the error.');
+  const stack = err.stack;
+
+  const fn = promisify(function (cb) {
+    cb(null);
+    cb(err);
+  });
+
+  (async () => {
+    await fn();
+    await Promise.resolve();
+    return assert.strictEqual(stack, err.stack);
+  })();
+}
+
+{
+  // Currently failing. Added comment on PR here https://github.com/nodejs/node/pull/12442/files#r112007329
+  // const c = function () { };
+  // const a = promisify(function () { });
+  // const b = promisify(a);
+  // assert.notEqual(c, a);
+  // assert.strictEqual(a, b);
+}
+
+{
+  let errToThrow;
+  const thrower = promisify(function (a, b, c, cb) {
+    errToThrow = new Error();
+    throw errToThrow;
+  });
+  thrower(1, 2, 3).then(assert.fail).then(assert.fail, (e) => assert(e === errToThrow));
+}
+
+{
+  const err = new Error();
+
+  const a = promisify(cb => cb(err))();
+  const b = promisify(() => { throw err; })();
+
+  Promise.all([
+    a.then(assert.fail, function (e) {
+      assert.equal(err, e);
+    }),
+    b.then(assert.fail, function (e) {
+      assert.equal(err, e);
+    })
+  ]);
+
+}


### PR DESCRIPTION
Adding tests to util.promisify, mainly from bluebird's Promise.promisify.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- ~~~documentation is changed or added~~~
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
`util`.

#goodnessSquad